### PR TITLE
Fix a mistype of .env on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Set values for env variables in the .env file, like as follow
     
     GITLAB_RUNNER=/example/git/runner
     
-    PROXY_LOGS=/exaple/proxy/logs
+    PROXY_LOGS=/example/proxy/logs
 
 Read .env:
 


### PR DESCRIPTION
Hi, I noticed a small mistype on README so I corrected it.
Thanks.